### PR TITLE
Syllabus Page Automatically Jump to Current Week

### DIFF
--- a/syllabus.md
+++ b/syllabus.md
@@ -50,9 +50,11 @@ for (var i = 0; i < lectures.length; i++ ) {
 
     // Need to look up the week element since it might be in the row above
     const weekEl = document.getElementById(`lecture-week-${lectureWeek}`);
-    weekEl.className += ' lecture__week--current'
+    weekEl.className += ' lecture__week--current';
+    window.location.hash = `lecture-week-${lectureWeek}`;
     break;
   }
+  
 }
 </script>
 


### PR DESCRIPTION
This commit adds a new feature that when the syllabus page is clicked. The page
will automatically jump to most current week. This feature is helpful for
student because as the course progress, students need to scroll long blobs of
text and resources. The most common destination will be the current week. Thus
this new feature.

Note that this completely depends on the highlighting feature. It that breaks,
autojump will not work. If it does not work, it won't break the website.

- Simon Mo